### PR TITLE
Make static building non-interactive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ ONBUILD RUN pipenv install --system
 ONBUILD COPY . /app/
 
 # Collect static files
-ONBUILD RUN python /app/manage.py collectstatic
+ONBUILD RUN python /app/manage.py collectstatic --noinput
 
 CMD ["django-run"]


### PR DESCRIPTION
Without this flag, the docker build fails because it gives the following prompt:

```
This will overwrite existing files!
Are you sure you want to do this?

Type 'yes' to continue, or 'no' to cancel: 
```